### PR TITLE
Issue 37 add validation to experience post

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,6 +59,16 @@ def experience():
 
     if request.method == "POST":
         request_data = request.get_json()
+        experienceProperties = ["title","company","start_date","end_date","description","logo"]
+        # Checks if an experience property is missing in request_data
+        for property in experienceProperties:
+            if property not in request_data:
+                return jsonify({"error":"Missing one or more input fields"}), 400
+        # Removes any unnecessary properties in request_data
+        for key in list(request_data.keys()):
+            if key not in experienceProperties:
+                del request_data[key]
+
         experience_data = Experience(**request_data)
         data["experience"].append(experience_data)
         index = len(data["experience"]) - 1

--- a/app.py
+++ b/app.py
@@ -59,14 +59,14 @@ def experience():
 
     if request.method == "POST":
         request_data = request.get_json()
-        experienceProperties = ["title","company","start_date","end_date","description","logo"]
+        experience_properties = ["title","company","start_date","end_date","description","logo"]
         # Checks if an experience property is missing in request_data
-        for property in experienceProperties:
-            if property not in request_data:
+        for prop in experience_properties:
+            if prop not in request_data:
                 return jsonify({"error":"Missing one or more input fields"}), 400
         # Removes any unnecessary properties in request_data
         for key in list(request_data.keys()):
-            if key not in experienceProperties:
+            if key not in experience_properties:
                 del request_data[key]
 
         experience_data = Experience(**request_data)

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -15,6 +15,7 @@ def test_client():
 
 def test_experience():
     """
+    First experience POST should be rejected due to bad data
     Add a new experience and then get all experiences.
 
     Check that it returns the new experience in that list
@@ -27,6 +28,13 @@ def test_experience():
         "description": "Writing JavaScript Code",
         "logo": "example-logo.png",
     }
+
+    bad_example_experience = {
+        "title": "Missing Developer",
+    }
+
+    bad_response = app.test_client().post("/resume/experience", json=bad_example_experience)
+    assert bad_response.status_code == 400
 
     item_id = (
         app.test_client().post("/resume/experience", json=example_experience).json["id"]


### PR DESCRIPTION
## Description
-Adds validation to the experience POST request
-Returns a 400 error if data is missing
-Removes any additional data that may be on the request object
-Adds test case for experience POST request with bad data

Closes #37 